### PR TITLE
4 cover existing functionality with unit tests

### DIFF
--- a/app/Http/Controllers/FacultyController.php
+++ b/app/Http/Controllers/FacultyController.php
@@ -39,13 +39,13 @@ class FacultyController extends Controller
         $searched = Faculty::find($code);
         if (is_null($searched)) {
             return response()->json([
-                "message" => "Faculty with code $code not found"
+                "message" => "Faculty with code $code not found."
             ], 404);
         }
 
         $request->validate(["faculty_name" => "required|string|max:100"]);
         $searched->faculty_name = $request->faculty_name;
         $searched->save();
-        return response()->json($searched, 200);
+        return response()->json($searched, 201);
     }
 }

--- a/tests/Feature/FacultyTest.php
+++ b/tests/Feature/FacultyTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class FacultyTest extends TestCase
+{
+    // use RefreshDatabase;
+    // test naming convention: test_{name of function/route args(or their absence)}_{anticipated result}
+
+    // retrieving faculties
+    public function test_getFaculties_noArgs_allFaculties(): void
+    {
+        $response = $this->get('/faculties');
+        $response->assertStatus(200);
+        $response->assertJsonIsArray();
+        $response->assertJsonStructure([
+            '*' => [
+                'faculty_code',
+                'faculty_name'
+            ]
+        ]);
+    }
+
+    public function test_getFaculties_routeWithID_oneFaculty(): void
+    {
+        $facultyCode='FIZ';
+        $response = $this->get('/faculties/'.$facultyCode);
+        $response->assertStatus(200);
+        $response->assertJsonIsObject();
+        $response->assertJsonStructure([
+            'faculty_code',
+            'faculty_name'
+        ]);
+        $response->assertExactJson([
+            'faculty_code' => 'FIZ',
+            'faculty_name' => 'Faculty of Physics'
+        ]);
+    }
+}

--- a/tests/Feature/FacultyTest.php
+++ b/tests/Feature/FacultyTest.php
@@ -42,4 +42,100 @@ class FacultyTest extends TestCase
             'faculty_name' => 'Faculty of Physics'
         ]);
     }
+
+    public function test_postFaculties_newValid_validPost(): void
+    {
+        $code_to_add = 'VBS';
+        $name_to_add = 'VU Busines School';
+        $response = $this->postJson('/faculties',
+            [
+                'faculty_code' => $code_to_add,
+                'faculty_name' => $name_to_add
+            ]
+        );
+
+        $response->assertStatus(201);
+        $response->assertJsonIsObject();
+        $response->assertExactJson(["faculty_code" => $code_to_add]);
+        $this->assertDatabaseHas('faculties', [
+            'faculty_code' => $code_to_add,
+            'faculty_name' => $name_to_add
+        ]);
+    }
+
+    public function test_postFaculties_invalidTooShortCode_error422Caught(): void
+    {
+        $response = $this->postJson('/faculties',
+            [
+                "faculty_code" => "VF",
+                "faculty_name" => "imaginary faculty"
+            ]
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure([
+            'message',
+            'errors' => [
+                'faculty_code' => []
+            ]
+        ]);
+    }
+
+    public function test_postFaculties_invalidTooLongCode_error422Caught(): void
+    {
+        $response = $this->postJson('/faculties',
+            [
+                "faculty_code" => "VFF1",
+                "faculty_name" => "imaginary faculty"
+            ]
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure([
+            'message',
+            'errors' => [
+                'faculty_code' => []
+            ]
+        ]);
+
+        $response->assertJsonPath("message", "The faculty code field must be 3 characters.");
+    }
+
+    public function test_postFaculties_invalidEmptyCode_error422Caught(): void
+    {
+        $response = $this->postJson('/faculties',
+            [
+                "faculty_code" => "",
+                "faculty_name" => "imaginary faculty"
+            ]
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure([
+            'message',
+            'errors' => [
+                'faculty_code' => []
+            ]
+        ]);
+        $response->assertJsonPath("message", "The faculty code field is required.");
+    }
+
+    public function test_postFaculties_invalidTakenCode_error422Caught(): void
+    {
+        $response = $this->postJson('/faculties',
+            [
+                "faculty_code" => "MIF",
+                "faculty_name" => "imaginary faculty"
+            ]
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure([
+            'message',
+            'errors' => [
+                'faculty_code' => []
+            ]
+        ]);
+        $response->assertJsonPath("message", "The faculty code has already been taken.");
+    }
 }

--- a/tests/Feature/FacultyTest.php
+++ b/tests/Feature/FacultyTest.php
@@ -216,4 +216,92 @@ class FacultyTest extends TestCase
         ]);
         $response->assertJsonPath("message", "The faculty name field must not be greater than 100 characters.");
     }
+
+    public function test_patchFaculties_NonExistingFacultyCode_error404Caught(): void
+    {
+        $faculty_code_to_modify_non_existing = 'FIF';
+        $response = $this->patchJson('/faculties/'.$faculty_code_to_modify_non_existing,
+            [
+                "faculty_name" => "New faculty name"
+            ]
+        );
+
+        $response->assertStatus(404);
+        $response->assertExactJson([
+            'message' => "Faculty with code $faculty_code_to_modify_non_existing not found.",
+        ]);
+    }
+
+    public function test_patchFaculties_emptyFacultyCode_error405Caught(): void
+    {
+        $faculty_code_to_modify_non_existing = '';
+        $response = $this->patchJson('/faculties/'.$faculty_code_to_modify_non_existing,
+            [
+                "faculty_name" => "New faculty name"
+            ]
+        );
+
+        $response->assertStatus(405); //method not allowed
+    }
+
+    public function test_patchFaculties_EmptyStringName_error422Caught(): void
+    {
+        $faculty_code_to_modify = 'FIZ';
+        $new_faculty_name = "";
+        $response = $this->patchJson('/faculties/'.$faculty_code_to_modify,
+            [
+                "faculty_name" => $new_faculty_name
+            ]
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure([
+            'message',
+            'errors' => [
+                'faculty_name' => []
+            ]
+        ]);
+        $response->assertJsonPath("message", "The faculty name field is required.");
+    }
+
+    public function test_patchFaculties_NonStringName_error422Caught(): void
+    {
+        $faculty_code_to_modify = 'FIZ';
+        $new_faculty_name = 41414;
+        $response = $this->patchJson('/faculties/'.$faculty_code_to_modify,
+            [
+                "faculty_name" => $new_faculty_name
+            ]
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure([
+            'message',
+            'errors' => [
+                'faculty_name' => []
+            ]
+        ]);
+        $response->assertJsonPath("message", "The faculty name field must be a string.");
+    }
+
+    public function test_patchFaculties_TooLongName_error422Caught(): void
+    {
+        $faculty_code_to_modify = 'FIZ';
+        $too_long_new_faculty_name = "Faculty of Mathematics and Computer ScienceFaculty of Mathematics and Computer ScienceFaculty of Math";
+        $this->assertTrue(strlen($too_long_new_faculty_name) === 101);
+        $response = $this->patchJson('/faculties/'.$faculty_code_to_modify,
+            [
+                "faculty_name" => $too_long_new_faculty_name
+            ]
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure([
+            'message',
+            'errors' => [
+                'faculty_name' => []
+            ]
+        ]);
+        $response->assertJsonPath("message", "The faculty name field must not be greater than 100 characters.");
+    }
 }

--- a/tests/Feature/FacultyTest.php
+++ b/tests/Feature/FacultyTest.php
@@ -3,19 +3,25 @@
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class FacultyTest extends TestCase
 {
-    // use RefreshDatabase;
+    use RefreshDatabase;
     // test naming convention: test_{name of function/route args(or their absence)}_{anticipated result}
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
 
     // retrieving faculties
     public function test_getFaculties_noArgs_allFaculties(): void
     {
-        $response = $this->get('/faculties');
-        $response->assertStatus(200);
+        $response = $this->get('/faculties'); // Act
+
+        $response->assertStatus(200); // Assert
         $response->assertJsonIsArray();
         $response->assertJsonStructure([
             '*' => [
@@ -28,8 +34,10 @@ class FacultyTest extends TestCase
     public function test_getFaculties_routeWithID_oneFaculty(): void
     {
         $facultyCode='FIZ';
-        $response = $this->get('/faculties/'.$facultyCode);
-        $response->assertStatus(200);
+        
+        $response = $this->get('/faculties/'.$facultyCode); // Act
+
+        $response->assertStatus(200); // Assert
         $response->assertJsonIsObject();
         $response->assertJsonStructure([
             'faculty_code',

--- a/tests/Feature/FacultyTest.php
+++ b/tests/Feature/FacultyTest.php
@@ -10,12 +10,6 @@ class FacultyTest extends TestCase
     use RefreshDatabase;
     // test naming convention: test_{name of function/route args(or their absence)}_{anticipated result}
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->seed();
-    }
-
     // retrieving faculties
     public function test_getFaculties_noArgs_allFaculties(): void
     {

--- a/tests/Feature/FacultyTest.php
+++ b/tests/Feature/FacultyTest.php
@@ -138,4 +138,82 @@ class FacultyTest extends TestCase
         ]);
         $response->assertJsonPath("message", "The faculty code has already been taken.");
     }
+
+    public function test_postFaculties_codeIsANumber_error422Caught(): void
+    {
+        $response = $this->postJson('/faculties',
+            [
+                "faculty_code" => 333,
+                "faculty_name" => "imaginary faculty"
+            ]
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure([
+            'message',
+            'errors' => [
+                'faculty_code' => []
+            ]
+        ]);
+        $response->assertJsonPath("message", "The faculty code field must be a string.");
+    }
+
+    public function test_postFaculties_nameEmpty_error422Caught(): void
+    {
+        $response = $this->postJson('/faculties',
+            [
+                "faculty_code" => "FIR",
+                "faculty_name" => ""
+            ]
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure([
+            'message',
+            'errors' => [
+                'faculty_name' => []
+            ]
+        ]);
+        $response->assertJsonPath("message", "The faculty name field is required.");
+    }
+
+    public function test_postFaculties_nameIsANumber_error422Caught(): void
+    {
+        $response = $this->postJson('/faculties',
+            [
+                "faculty_code" => "FIR",
+                "faculty_name" => 333
+            ]
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure([
+            'message',
+            'errors' => [
+                'faculty_name' => []
+            ]
+        ]);
+        $response->assertJsonPath("message", "The faculty name field must be a string.");
+    }
+
+    public function test_postFaculties_nameIsTooLong_error422Caught(): void
+    {
+        $too_long_faculty_name = "Faculty of Mathematics and Computer ScienceFaculty of Mathematics and Computer ScienceFaculty of Math";
+        $this->assertTrue(strlen($too_long_faculty_name) === 101);
+        $response = $this->postJson('/faculties',
+            [
+                "faculty_code" => "FIR",
+                "faculty_name" => $too_long_faculty_name
+            ]
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure([
+            'message',
+            'errors' => [
+                'faculty_name' => []
+            ]
+        ]);
+        $response->assertJsonPath("message", "The faculty name field must not be greater than 100 characters.");
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,5 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected $seed = true;
 }

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -6,10 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class ExampleTest extends TestCase
 {
-    /**
-     * A basic test example.
-     */
-    public function test_that_true_is_true(): void
+    public function test_canary(): void
     {
         $this->assertTrue(true);
     }


### PR DESCRIPTION
Setup canary test. 
Add feature tests for **/faculties** endpoint. 
Return 201 instead of 200 when patching faculty name.
